### PR TITLE
Conflict happens with FCM plugin

### DIFF
--- a/src/android/Hotline/build.gradle
+++ b/src/android/Hotline/build.gradle
@@ -5,5 +5,5 @@ repositories{
 
 dependencies {
     compile 'com.github.freshdesk:hotline-android:1.2.1'
-	compile 'com.google.android.gms:play-services-gcm:+'
+	//compile 'com.google.android.gms:play-services-gcm:+'
 }


### PR DESCRIPTION
compile 'com.google.android.gms:play-services-gcm:+' makes conflict 

* What went wrong:
Execution failed for task ':processDebugGoogleServices'.
> Please fix the version conflict either by updating the version of the google-services plugin (information about the latest version is available at https://bintray.com/android/android-tools/com.google.gms.google-services/) or updating the version of com.google.android.gms to 9.0.0.